### PR TITLE
Postponed server's start

### DIFF
--- a/cliche-shell-core/src/main/java/com/maxifier/cliche/ShellFactory.java
+++ b/cliche-shell-core/src/main/java/com/maxifier/cliche/ShellFactory.java
@@ -5,11 +5,10 @@
 
 package com.maxifier.cliche;
 
+import com.google.common.collect.Lists;
 import com.maxifier.cliche.util.ArrayHashMultiMap;
 import com.maxifier.cliche.util.EmptyMultiMap;
 import com.maxifier.cliche.util.MultiMap;
-
-import com.google.common.collect.Lists;
 import jline.console.ConsoleReader;
 import org.apache.sshd.SshServer;
 import org.apache.sshd.common.Factory;
@@ -125,8 +124,7 @@ public class ShellFactory {
     public static Collection<?> createSshShell(final SshServer server,
                                                final String promt,
                                                final String appName,
-                                               final Object... handlers) {
-        final Collection<?> handlersCollection = Lists.newArrayList(handlers);
+                                               final Collection handlersCollection) {
         Thread shellThread = new Thread(new Runnable() {
             @Override
             public void run() {

--- a/cliche-shell-core/src/main/java/com/maxifier/cliche/example/ConsoleReaderTest.java
+++ b/cliche-shell-core/src/main/java/com/maxifier/cliche/example/ConsoleReaderTest.java
@@ -1,5 +1,6 @@
 package com.maxifier.cliche.example;
 
+import com.google.common.collect.ImmutableList;
 import com.maxifier.cliche.ShellFactory;
 
 import org.apache.sshd.SshServer;
@@ -31,7 +32,7 @@ public class ConsoleReaderTest {
 //        });
         sshServer.setPort(12890);
         sshServer.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser"));
-        ShellFactory.createSshShell(sshServer, "welcome", "Test ssh app with console reader", new Example());
+        ShellFactory.createSshShell(sshServer, "welcome", "Test ssh app with console reader", ImmutableList.of(new Example()));
         sshServer.start();
 
 

--- a/cliche-shell-guice/src/main/java/com/maxifier/cliche/guice/SshShellLauncher.java
+++ b/cliche-shell-guice/src/main/java/com/maxifier/cliche/guice/SshShellLauncher.java
@@ -1,0 +1,70 @@
+/*
+* Copyright (c) 2008-2013 Maxifier Ltd. All Rights Reserved.
+*/
+package com.maxifier.cliche.guice;
+
+import com.maxifier.cliche.ResourceHostKeyProvider;
+import com.maxifier.cliche.ShellFactory;
+import com.maxifier.cliche.SshNonInteractiveShellCommand;
+import org.apache.sshd.SshServer;
+import org.apache.sshd.server.Command;
+import org.apache.sshd.server.CommandFactory;
+import org.apache.sshd.server.PasswordAuthenticator;
+import org.apache.sshd.server.PublickeyAuthenticator;
+import org.apache.sshd.server.session.ServerSession;
+
+import java.io.IOException;
+import java.security.PublicKey;
+import java.util.Collection;
+
+/**
+ * It is intended for launch ssh-server with specified port, name and shellHandlers.<p/>
+ * {@link SshShellLauncher#shellHandlers} is collection of shell handlers, which will be used for initializing the new shell,
+ * when a new user connects to the ssh-server.
+ *
+ * @author Igor Yankov (igor.yankov@maxifier.com) (2013-10-11 10:00)
+ */
+public class SshShellLauncher {
+    private final String prompt;
+    private final String appName;
+    private final int port;
+    private final Collection shellHandlers;
+
+    public SshShellLauncher(String prompt, String appName, int port, Collection shellHandlers) {
+        this.prompt = prompt;
+        this.appName = appName;
+        this.port = port;
+        this.shellHandlers = shellHandlers;
+    }
+
+    public void startSshServer() {
+        SshServer sshServer = SshServer.setUpDefaultServer();
+        sshServer.setPublickeyAuthenticator(new PublickeyAuthenticator() {
+            @Override
+            public boolean authenticate(String username, PublicKey key, ServerSession session) {
+                return true;
+            }
+        });
+        sshServer.setPasswordAuthenticator(new PasswordAuthenticator() {
+            @Override
+            public boolean authenticate(String username, String password, ServerSession session) {
+                return true;
+            }
+        });
+        sshServer.setPort(port);
+        sshServer.setKeyPairProvider(new ResourceHostKeyProvider(".hostkey"));
+        ShellFactory.createSshShell(sshServer, prompt, appName, shellHandlers);
+        sshServer.setCommandFactory(new CommandFactory() {
+            @Override
+            public Command createCommand(String command) {
+                return new SshNonInteractiveShellCommand(command, shellHandlers);
+            }
+        });
+        try {
+            sshServer.start();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/cliche-shell-guice/src/main/java/com/maxifier/cliche/guice/SshShellModule.java
+++ b/cliche-shell-guice/src/main/java/com/maxifier/cliche/guice/SshShellModule.java
@@ -1,72 +1,45 @@
 package com.maxifier.cliche.guice;
 
+import com.google.common.collect.Lists;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
-import com.maxifier.cliche.ResourceHostKeyProvider;
-import com.maxifier.cliche.ShellFactory;
-import com.maxifier.cliche.SshNonInteractiveShellCommand;
-import org.apache.sshd.SshServer;
-import org.apache.sshd.common.KeyPairProvider;
-import org.apache.sshd.common.keyprovider.FileKeyPairProvider;
-import org.apache.sshd.common.keyprovider.ResourceKeyPairProvider;
-import org.apache.sshd.server.Command;
-import org.apache.sshd.server.CommandFactory;
-import org.apache.sshd.server.PasswordAuthenticator;
-import org.apache.sshd.server.PublickeyAuthenticator;
-import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
-import org.apache.sshd.server.session.ServerSession;
 
-import java.io.File;
-import java.io.IOException;
-import java.security.PublicKey;
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * @author aleksey.didik@maxifier.com (Aleksey Didik)
  */
 public class SshShellModule extends AbstractModule {
 
-    private final String promt;
+    private final String prompt;
     private final String appName;
     private final int port;
+    private boolean postponedStart;
 
-    public SshShellModule(String promt, String appName, int port) {
-        this.promt = promt;
+    public SshShellModule(String prompt, String appName, int port) {
+        this(false, prompt, appName, port);
+    }
+
+    public SshShellModule(boolean postponedStart, String prompt, String appName, int port) {
+        this.prompt = prompt;
         this.appName = appName;
         this.port = port;
+        this.postponedStart = postponedStart;
     }
 
     @Override
     protected void configure() {
-        SshServer sshServer = SshServer.setUpDefaultServer();
-        sshServer.setPublickeyAuthenticator(new PublickeyAuthenticator() {
-            @Override
-            public boolean authenticate(String username, PublicKey key, ServerSession session) {
-                return true;
-            }
-        });
-        sshServer.setPasswordAuthenticator(new PasswordAuthenticator() {
-            @Override
-            public boolean authenticate(String username, String password, ServerSession session) {
-                return true;
-            }
-        });
-        sshServer.setPort(port);
-        sshServer.setKeyPairProvider(new ResourceHostKeyProvider(".hostkey"));
-        final Collection shellHandlers = ShellFactory.createSshShell(sshServer, promt, appName);
-        sshServer.setCommandFactory(new CommandFactory() {
-            @Override
-            public Command createCommand(String command) {
-                return new SshNonInteractiveShellCommand(command, shellHandlers);
-            }
-        });
-        try {
-            sshServer.start();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        final Collection shellHandlers = Collections.synchronizedCollection(Lists.newArrayList());
+
+        SshShellLauncher serverStarter = new SshShellLauncher(prompt, appName, port, shellHandlers);
+        if (postponedStart) {
+            bind(SshShellLauncher.class).toInstance(serverStarter);
+        } else {
+            serverStarter.startSshServer();
         }
         bindListener(AnnotatedClassMatcher.with(CommandHandler.class),
                 new TypeListener() {
@@ -82,7 +55,6 @@ public class SshShellModule extends AbstractModule {
                 }
         );
     }
-
 
 
 }


### PR DESCRIPTION
SSH-server is able to be started not during module's configuration
but after the guice conatiner is built. This allows firstly to complete
the container creation and only after that to expose ssh interface
